### PR TITLE
Disable api by default, not needed and port conflicts

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -52,7 +52,7 @@
 	},
 
 	"api": {
-		"enabled": true,
+		"enabled": false,
 		"purgeOnly": false,
 		"purgeInterval": "10m",
 		"listen": "0.0.0.0:30300",


### PR DESCRIPTION
Should disable api by default since its not needed for stratum. It also prevents multiple stratum instances from running on the same machine.