### PR TITLE
Fix bug with header number

### DIFF
--- a/proxy/stratum.go
+++ b/proxy/stratum.go
@@ -223,7 +223,7 @@ func (cs *Session) pushNewJob(header *types.Header) error {
 		Method: "mining.notify",
 		Params: []string{
 			fmt.Sprintf("%x", header.SealHash()),
-			fmt.Sprintf("%x", header.Number()),
+			fmt.Sprintf("%x", header.Number(common.ZONE_CTX)),
 			fmt.Sprintf("%x", header.SealHash()),
 			"0",
 		},


### PR DESCRIPTION
Header.number() returns Prime number by default.