### PR TITLE
Increase max errors to 999

### DIFF
--- a/proxy/stratum.go
+++ b/proxy/stratum.go
@@ -131,7 +131,7 @@ func (cs *Session) handleTCPMessage(s *ProxyServer, req *Request) error {
 				"encoding":  "plain",
 				"resume":    0,
 				"timeout":   30,
-				"maxerrors": 5,
+				"maxerrors": 999,
 				"node":      "go-quai/development",
 			},
 		}


### PR DESCRIPTION
Needed to prevent GPU miners from disconnecting while we figure out the reason for stale shares.