### PR TITLE
Homogenous naming in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # with Go source code. If you know what GOPATH is then you probably
 # don't need to bother with make.
 
-.PHONY: all test clean quai-stratum
+.PHONY: all test clean go-quai-stratum
 
 GOBIN = ./build/bin
 GOGET = env GO111MODULE=on go get
@@ -20,7 +20,7 @@ clean:
 	rm -fr build/_workspace/pkg/ $(GOBIN)/*
 
 debug:
-	$(GOBUILD) -gcflags="all=-N -l" -o ./build/bin/quai-stratum ./main.go
+	$(GOBUILD) -gcflags="all=-N -l" -o ./build/bin/go-quai-stratum ./main.go
 
-quai-stratum:
-	$(GOBUILD) -o ./build/bin/quai-stratum ./main.go
+go-quai-stratum:
+	$(GOBUILD) -o ./build/bin/go-quai-stratum ./main.go

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Within the config.json file, you'll be able to configure networking settings and
 ## Build
 Before running the proxy, we need to build the source. You can build via Makefile by running the following command:
 ```bash
-make quai-stratum
+make go-quai-stratum
 ```
 ## Run
 Now that we've built the source, we can start our proxy We recommend using a process manager program like tmux or screen to run the proxy.


### PR DESCRIPTION
* Prior to this PR, the repository name was `go-quai-stratum` and the makefile command to build the binary was `make quai-stratum` which caused some confusion.

* This PR changes the makefile command to `make go-quai-stratum` to match the repository name.