### PR TITLE
Only start listening to miner connections after first block template …

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -104,11 +104,6 @@ func NewProxy(cfg *Config, backend *storage.RedisClient) *ProxyServer {
 
 	proxy.rng = rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	if cfg.Proxy.Stratum.Enabled {
-		proxy.sessions = make(map[*Session]struct{})
-		go proxy.ListenTCP()
-	}
-
 	proxy.hashrateExpiration = util.MustParseDuration(cfg.Proxy.HashrateExpiration)
 
 	refreshIntv := util.MustParseDuration(cfg.Proxy.BlockRefreshInterval)
@@ -118,6 +113,11 @@ func NewProxy(cfg *Config, backend *storage.RedisClient) *ProxyServer {
 	stateUpdateIntv := util.MustParseDuration(cfg.Proxy.StateUpdateInterval)
 	stateUpdateTimer := time.NewTimer(stateUpdateIntv)
 	proxy.fetchBlockTemplate()
+
+	if cfg.Proxy.Stratum.Enabled {
+		proxy.sessions = make(map[*Session]struct{})
+		go proxy.ListenTCP()
+	}
 
 	go func() {
 		for {


### PR DESCRIPTION
Previously there would be a race condition where a miner could connect before the first block template was found. This would cause a crash when the miner asked for the block template to start mining.

Now the block template fetching happens in a blocking manner and the tcp ports only open after it has been successfully retrieved.